### PR TITLE
feat: add hero background and navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,10 +13,19 @@
 </head>
 <body>
   <header class="hero">
-    <img src="flcoya-logo.png" alt="falcoya logo" class="logo" />
-    <h1>Craft more than detect.</h1>
-    <p class="sub">小さな調整で、大きく静かな安全を。</p>
-    <a href="#plans" class="cta">Start now</a>
+    <nav class="navbar">
+      <img src="flcoya-logo.png" alt="falcoya logo" class="logo" />
+      <ul class="nav-links">
+        <li><a href="#proof">Proof</a></li>
+        <li><a href="#how">How</a></li>
+        <li><a href="#plans">Plans</a></li>
+      </ul>
+    </nav>
+    <div class="hero-content">
+      <h1>Craft more than detect.</h1>
+      <p class="sub">小さな調整で、大きく静かな安全を。</p>
+      <a href="#plans" class="cta">Start now</a>
+    </div>
   </header>
 
   <section id="metrics" class="metrics">

--- a/styles.css
+++ b/styles.css
@@ -19,22 +19,48 @@ h1, h2, h3 {
   margin: 0 0 1rem;
 }
 .hero {
-  text-align: center;
-  padding: 4rem 1rem;
+  background: url('img/design1.png') center/cover no-repeat;
+  color: #fff;
+  padding: 2rem 1rem 6rem;
+}
+.navbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 4rem;
+}
+.nav-links {
+  list-style: none;
+  display: flex;
+  gap: 1.5rem;
+  margin: 0;
+  padding: 0;
+}
+.nav-links a {
+  color: #fff;
+  text-decoration: none;
+  font-weight: 500;
 }
 .hero .logo {
   width: 120px;
   animation: pulse 4s ease-in-out infinite;
+}
+.hero-content {
+  text-align: center;
+  margin-top: 4rem;
 }
 @keyframes pulse {
   0%, 100% { filter: drop-shadow(0 0 0 rgba(0,0,0,0)); }
   50% { filter: drop-shadow(0 0 16px rgba(106,0,255,0.6)); }
 }
 .hero h1 {
-  font-size: 2.5rem;
+  font-size: 3rem;
   background: linear-gradient(90deg, var(--accent-start), var(--accent-end));
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
+}
+.hero .sub {
+  font-size: 1.25rem;
 }
 .cta {
   display: inline-block;


### PR DESCRIPTION
## Summary
- add navigation bar and hero content container
- apply design1 background and text styling for hero section

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689936fe97a4832c9a27cd37e997cd9d