### PR TITLE
fix: ブログ記事ページの言語切り替え機能を修正

### DIFF
--- a/pages/blog/falco-nginx-security-tutorial-en.js
+++ b/pages/blog/falco-nginx-security-tutorial-en.js
@@ -1,10 +1,12 @@
 import Head from 'next/head'
 import Link from 'next/link'
 import { useState, useEffect } from 'react'
+import { useRouter } from 'next/router'
 
 export default function FalcoNginxTutorialEn() {
   const [language, setLanguage] = useState('en')
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
+  const router = useRouter()
   
   // 画面サイズ変更時にモバイルメニューを閉じる
   useEffect(() => {
@@ -68,13 +70,20 @@ export default function FalcoNginxTutorialEn() {
             <div className="language-switcher">
               <button 
                 className={`lang-btn ${language === 'ja' ? 'active' : ''}`}
-                onClick={() => setLanguage('ja')}
+                onClick={() => {
+                  setLanguage('ja')
+                  // 日本語版の記事ページへリダイレクト
+                  router.push('/blog/falco-nginx-security-tutorial')
+                }}
               >
                 日本語
               </button>
               <button 
                 className={`lang-btn ${language === 'en' ? 'active' : ''}`}
-                onClick={() => setLanguage('en')}
+                onClick={() => {
+                  setLanguage('en')
+                  // 既に英語ページにいるので何もしない
+                }}
               >
                 English
               </button>

--- a/pages/blog/falco-nginx-security-tutorial.js
+++ b/pages/blog/falco-nginx-security-tutorial.js
@@ -1,10 +1,12 @@
 import Head from 'next/head'
 import Link from 'next/link'
 import { useState, useEffect } from 'react'
+import { useRouter } from 'next/router'
 
 export default function FalcoNginxTutorial() {
   const [language, setLanguage] = useState('ja')
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
+  const router = useRouter()
   
   // 画面サイズ変更時にモバイルメニューを閉じる
   useEffect(() => {
@@ -68,13 +70,20 @@ export default function FalcoNginxTutorial() {
             <div className="language-switcher">
               <button 
                 className={`lang-btn ${language === 'ja' ? 'active' : ''}`}
-                onClick={() => setLanguage('ja')}
+                onClick={() => {
+                  setLanguage('ja')
+                  // 既に日本語ページにいるので何もしない
+                }}
               >
                 日本語
               </button>
               <button 
                 className={`lang-btn ${language === 'en' ? 'active' : ''}`}
-                onClick={() => setLanguage('en')}
+                onClick={() => {
+                  setLanguage('en')
+                  // 英語版の記事ページへリダイレクト
+                  router.push('/blog/falco-nginx-security-tutorial-en')
+                }}
               >
                 English
               </button>


### PR DESCRIPTION
## 概要
ブログ記事ページで言語切り替えボタンが機能していなかった問題を修正しました。

## 問題点
- 日本語記事で「English」ボタンを押しても英語版に切り替わらない
- 英語記事で「日本語」ボタンを押しても日本語版に切り替わらない

## 修正内容
- `useRouter`を使用してページ遷移を実装
- 日本語記事ページ → 英語ボタンクリックで `/blog/falco-nginx-security-tutorial-en` へ遷移
- 英語記事ページ → 日本語ボタンクリックで `/blog/falco-nginx-security-tutorial` へ遷移

## 対象ファイル
- `/pages/blog/falco-nginx-security-tutorial.js`
- `/pages/blog/falco-nginx-security-tutorial-en.js`

## テスト項目
- [x] 日本語記事から英語記事への切り替え
- [x] 英語記事から日本語記事への切り替え

🤖 Generated with [Claude Code](https://claude.ai/code)