### PR TITLE
Fix: Mobile menu rotation display issue

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2096,10 +2096,6 @@ body {
   
   .desktop-menu {
     display: flex !important;
-  }
-  
-  .nav-menu {
-    display: flex !important;
     gap: 2rem;
   }
 }


### PR DESCRIPTION
## 問題
携帯を横向きから縦向きに戻した際に、'Blog'メニューだけが画面上部に残って表示される問題を修正しました。

## 原因
`.nav-menu`クラスに`display: flex \!important`が適用されていたため、`.desktop-menu`を非表示にしても基底の`.nav-menu`スタイルが残ってしまっていました。

## 修正内容
- デスクトップメディアクエリから重複する`.nav-menu`のflexスタイルを削除
- `.desktop-menu`クラスのみでデスクトップ用のflexレイアウトを管理するように変更

## テスト方法
1. 携帯デバイスで縦向きでサイトを開く
2. 横向きに回転（全メニューが表示される）
3. 縦向きに戻す
4. メニューが正しく折りたたまれることを確認