### PR TITLE
feat: テストレポートを300パターンに更新

### DIFF
--- a/pages/news.js
+++ b/pages/news.js
@@ -30,6 +30,27 @@ export default function News() {
       },
       items: [
         {
+          id: "2026-01-10-quality-300-update",
+          date: "2026-01-10",
+          category: "feature",
+          type: "update",
+          title: "テストパターンを300に拡大",
+          content: "E2Eテストパターンを225から300に拡大しました。SSTIを独立カテゴリとして追加し、全カテゴリでテストパターンを強化。E2E Run #82で300パターン全て検知率100%を達成しました。",
+          highlights: [
+            "テストパターン 225 → 300 拡張",
+            "SQLi: 79パターン（26.3%）",
+            "XSS: 56パターン（18.7%）",
+            "Path Traversal: 45パターン（15.0%）",
+            "Command Injection: 41パターン（13.7%）",
+            "SSTI: 15パターン（5.0%）- 独立カテゴリ化",
+            "XXE: 11パターン（3.7%）",
+            "LDAP Injection: 15パターン（5.0%）",
+            "検知率 100% 達成（E2E Run #82）",
+            "ロードマップ進捗 35.3%（850パターン目標）"
+          ],
+          link: "/quality"
+        },
+        {
           id: "2026-01-03-oss-development-blog-part24",
           date: "2026-01-03",
           category: "feature",
@@ -599,6 +620,27 @@ export default function News() {
         bugfix: "Bug Fixes"
       },
       items: [
+        {
+          id: "2026-01-10-quality-300-update-en",
+          date: "2026-01-10",
+          category: "feature",
+          type: "update",
+          title: "Test Patterns Expanded to 300",
+          content: "E2E test patterns expanded from 225 to 300. SSTI added as independent category, strengthened test patterns across all categories. Achieved 100% detection rate across all 300 patterns in E2E Run #82.",
+          highlights: [
+            "Test patterns expanded: 225 → 300",
+            "SQLi: 79 patterns (26.3%)",
+            "XSS: 56 patterns (18.7%)",
+            "Path Traversal: 45 patterns (15.0%)",
+            "Command Injection: 41 patterns (13.7%)",
+            "SSTI: 15 patterns (5.0%) - Now independent category",
+            "XXE: 11 patterns (3.7%)",
+            "LDAP Injection: 15 patterns (5.0%)",
+            "100% detection rate achieved (E2E Run #82)",
+            "Roadmap progress: 35.3% (850 patterns goal)"
+          ],
+          link: "/quality"
+        },
         {
           id: "2026-01-03-oss-development-blog-part24-en",
           date: "2026-01-03",

--- a/pages/quality.js
+++ b/pages/quality.js
@@ -9,12 +9,12 @@ export default function Quality() {
   const [activePhase, setActivePhase] = useState('phase2') // Default to Phase 2
   const [runNumber, setRunNumber] = useState('')
 
-  // Phase 2 test data (225 patterns)
+  // Phase 2 test data (300 patterns)
   const phase2Data = {
     metadata: {
-      runNumber: 69,
-      timestamp: "2026-01-02T12:00:00Z",
-      duration: "626ms",
+      runNumber: 82,
+      timestamp: "2026-01-10T12:00:00Z",
+      duration: "762ms",
       environment: {
         platform: "ubuntu-24.04",
         falcoVersion: "0.42.1",
@@ -24,19 +24,20 @@ export default function Quality() {
       }
     },
     summary: {
-      totalTests: 225,
-      passedTests: 225,
+      totalTests: 300,
+      passedTests: 300,
       failedTests: 0,
       passRate: 100
     },
     categories: {
-      SQLI: { count: 59, percentage: 26.2 },
-      XSS: { count: 41, percentage: 18.2 },
-      PATH: { count: 40, percentage: 17.8 },
-      CMDINJ: { count: 34, percentage: 15.1 },
-      XXE: { count: 11, percentage: 4.9 },
-      LDAP: { count: 10, percentage: 4.4 },
-      OTHER: { count: 30, percentage: 13.3 }
+      SQLI: { count: 79, percentage: 26.3 },
+      XSS: { count: 56, percentage: 18.7 },
+      PATH: { count: 45, percentage: 15.0 },
+      CMDINJ: { count: 41, percentage: 13.7 },
+      SSTI: { count: 15, percentage: 5.0 },
+      XXE: { count: 11, percentage: 3.7 },
+      LDAP: { count: 15, percentage: 5.0 },
+      OTHER: { count: 38, percentage: 12.7 }
     },
     urls: {
       latest: "https://takaosgb3.github.io/falco-plugin-nginx/e2e-report/latest/",
@@ -73,11 +74,11 @@ export default function Quality() {
       },
       hero: {
         title: "E2E テストレポート",
-        subtitle: "225パターンの攻撃検知をAllureで可視化",
+        subtitle: "300パターンの攻撃検知をAllureで可視化",
         description: "falco-plugin-nginx の品質は、包括的なE2Eテスト、自動化されたCI/CD、実証済みの検知精度、そして Falcoya君の頑張りによって支えられています。"
       },
       phaseSelector: {
-        phase2: "Phase 2: 攻撃検知 (225パターン)",
+        phase2: "Phase 2: 攻撃検知 (300パターン)",
         phase1: "Phase 1: 基礎検証 (14テスト)"
       },
       phase2: {
@@ -95,9 +96,10 @@ export default function Quality() {
           xss: { name: "クロスサイトスクリプティング", desc: "DOM、Reflected、Stored、Encoding等" },
           path: { name: "パストラバーサル", desc: "../etc/passwd、エンコーディング回避等" },
           cmdinj: { name: "コマンドインジェクション", desc: "Backtick、Pipe、Substitution等" },
+          ssti: { name: "サーバサイドテンプレートインジェクション", desc: "Jinja2、Twig、Freemarker等" },
           xxe: { name: "XML外部実体参照", desc: "Entity、JAR、Billion Laugh攻撃等" },
           ldap: { name: "LDAPインジェクション", desc: "認証バイパス、Blind LDAP等" },
-          other: { name: "その他", desc: "XPath、SSTI、GraphQL、NoSQL等" },
+          other: { name: "その他", desc: "XPath、GraphQL、NoSQL、API Security等" },
           patterns: "パターン"
         },
         buttons: {
@@ -179,11 +181,11 @@ export default function Quality() {
       },
       hero: {
         title: "E2E Test Report",
-        subtitle: "225 Attack Patterns Visualized with Allure",
+        subtitle: "300 Attack Patterns Visualized with Allure",
         description: "The quality of falco-plugin-nginx is supported by comprehensive E2E testing, automated CI/CD, proven detection accuracy, and Falcoya-kun's dedication."
       },
       phaseSelector: {
-        phase2: "Phase 2: Attack Detection (225 Patterns)",
+        phase2: "Phase 2: Attack Detection (300 Patterns)",
         phase1: "Phase 1: Foundation Verification (14 Tests)"
       },
       phase2: {
@@ -201,9 +203,10 @@ export default function Quality() {
           xss: { name: "Cross-Site Scripting", desc: "DOM, Reflected, Stored, Encoding, etc." },
           path: { name: "Path Traversal", desc: "../etc/passwd, encoding bypass, etc." },
           cmdinj: { name: "Command Injection", desc: "Backtick, Pipe, Substitution, etc." },
+          ssti: { name: "Server-Side Template Injection", desc: "Jinja2, Twig, Freemarker, etc." },
           xxe: { name: "XML External Entity", desc: "Entity, JAR, Billion Laugh attack, etc." },
           ldap: { name: "LDAP Injection", desc: "Auth bypass, Blind LDAP, etc." },
-          other: { name: "Other", desc: "XPath, SSTI, GraphQL, NoSQL, etc." },
+          other: { name: "Other", desc: "XPath, GraphQL, NoSQL, API Security, etc." },
           patterns: "patterns"
         },
         buttons: {
@@ -660,7 +663,7 @@ export default function Quality() {
               <div className="roadmap-stats">
                 <div className="roadmap-stat">
                   <span className="roadmap-label">{currentContent.roadmap.current}</span>
-                  <span className="roadmap-value">225 {currentContent.roadmap.patterns}</span>
+                  <span className="roadmap-value">300 {currentContent.roadmap.patterns}</span>
                 </div>
                 <div className="roadmap-stat">
                   <span className="roadmap-label">{currentContent.roadmap.target}</span>
@@ -669,9 +672,9 @@ export default function Quality() {
               </div>
               <div className="roadmap-progress">
                 <div className="progress-bar-container">
-                  <div className="progress-bar" style={{ width: '26.5%' }}></div>
+                  <div className="progress-bar" style={{ width: '35.3%' }}></div>
                 </div>
-                <span className="progress-percentage">26.5%</span>
+                <span className="progress-percentage">35.3%</span>
               </div>
               <p className="roadmap-description">{currentContent.roadmap.description}</p>
             </div>


### PR DESCRIPTION
## Summary
- E2Eテストパターンを225から300に拡大（Run #82）
- SSTIを独立カテゴリとして追加
- quality ページと news ページを更新

## Changes
### quality.js
- phase2Data を Run #82 (300パターン) に更新
- カテゴリ別パターン数:
  - SQLI: 79 (26.3%)
  - XSS: 56 (18.7%)
  - PATH: 45 (15.0%)
  - CMDINJ: 41 (13.7%)
  - SSTI: 15 (5.0%) - 新規独立カテゴリ
  - XXE: 11 (3.7%)
  - LDAP: 15 (5.0%)
  - OTHER: 38 (12.7%)
- Roadmap進捗率: 26.5% → 35.3%
- 日本語/英語テキスト更新

### news.js
- 300パターン達成ニュースを追加（日本語/英語）

## Test plan
- [x] `npm run lint` - エラーなし
- [x] `npm run build` - 成功
- [ ] https://staging.falcoya.dev/quality で表示確認
- [ ] https://staging.falcoya.dev/news で表示確認
- [ ] 日本語/英語両方の表示確認

Closes #14

🤖 Generated with [Claude Code](https://claude.ai/claude-code)